### PR TITLE
fix: 인증코드 type number -> string 변경

### DIFF
--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -24,7 +24,7 @@ export interface IPhoneNumber {
 }
 
 export interface IPhoneAuth extends IPhoneNumber {
-  code: number;
+  code: string;
 }
 
 export interface IUserInfo {
@@ -43,12 +43,12 @@ export interface IEmail {
   emailAddress: string;
 }
 export interface IEmailAuth extends IEmail {
-  code: number;
+  code: string;
 }
 
 export interface IEmailAuth2 {
   emailAddress: string;
-  code: number;
+  code: string;
 }
 
 export interface ITokenRefresh {

--- a/src/components/findpassword/EmailCertification.tsx
+++ b/src/components/findpassword/EmailCertification.tsx
@@ -28,7 +28,7 @@ const EmailCertification = ({ setStep }: EmailCertificationProps) => {
   });
 
   const { mutateAsync: emailVerify } = useMutation(
-    ({ emailAddress, code }: { emailAddress: string; code: number }) => {
+    ({ emailAddress, code }: { emailAddress: string; code: string }) => {
       return emailauthverify({ emailAddress, code });
     }
   );
@@ -117,7 +117,7 @@ const EmailCertification = ({ setStep }: EmailCertificationProps) => {
       try {
         const { status } = (await emailVerify({
           emailAddress: userEmail,
-          code: Number(validNumber)
+          code: validNumber
         })) as { status: string };
 
         if (status == 'SUCCESS') {

--- a/src/components/signup/EmailVerification.tsx
+++ b/src/components/signup/EmailVerification.tsx
@@ -31,7 +31,7 @@ const EmailVerification = ({ onNext }: EmailVerification) => {
   });
 
   const { mutateAsync: emailVerify } = useMutation(
-    ({ emailAddress, code }: { emailAddress: string; code: number }) => {
+    ({ emailAddress, code }: { emailAddress: string; code: string }) => {
       return emailauthverify({ emailAddress, code });
     }
   );
@@ -80,7 +80,7 @@ const EmailVerification = ({ onNext }: EmailVerification) => {
       try {
         const { status } = (await emailVerify({
           emailAddress: userEmail,
-          code: Number(validNumber)
+          code: validNumber
         })) as { status: string };
 
         if (status == 'SUCCESS') {

--- a/src/components/signup/PhoneCertification.tsx
+++ b/src/components/signup/PhoneCertification.tsx
@@ -30,7 +30,7 @@ const PhoneCertification = ({ onNext }: PhoneCertificationProps) => {
   });
 
   const { mutateAsync: phoneVerify } = useMutation(
-    ({ phoneNumber, code }: { phoneNumber: string; code: number }) => {
+    ({ phoneNumber, code }: { phoneNumber: string; code:string }) => {
       return phoneauthverify({ phoneNumber, code });
     }
   );
@@ -114,6 +114,8 @@ const PhoneCertification = ({ onNext }: PhoneCertificationProps) => {
 
     if (btnStatus == 'THIRD') {
       if (validNumber.length != 6) {
+        console.log(validNumber)
+        
         setValidNumber('');
         setErrorMessage('6자리 코드를 입력해주세요.');
         inputRef.current?.focus();
@@ -122,7 +124,7 @@ const PhoneCertification = ({ onNext }: PhoneCertificationProps) => {
       try {
         const { status } = await phoneVerify({
           phoneNumber: phoneNumber.replace(/-/g, ''),
-          code: Number(validNumber)
+          code: validNumber
         });
 
         if (status == 'SUCCESS') {
@@ -134,6 +136,9 @@ const PhoneCertification = ({ onNext }: PhoneCertificationProps) => {
         const select = signError.find((item) => item.errorCode === errorCode);
         if (select) {
           setErrorMessage(select.message);
+          console.log(validNumber);
+          console.log(parseInt(validNumber, 10));
+          console.log(Number(validNumber));
           setValidNumber('');
           inputRef.current?.focus();
           return;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 휴대폰 및 이메일 인증코드 오류 수정

<!-- 어떤 작업을 했는지 -->

### How it Works
휴대폰 및 이메일 인증코드 입력할 때 첫 자리가 0인 경우 0을 제외하고 전달되는 문제가 발생해서(ex: code = 012345 -> 12345 로 전달됨),
인증코드 타입을 number -> string 으로 변경하였습니다.
